### PR TITLE
feat(role): add capability to make coder compatible with ports < 1024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Coder v2 Install
 
 This Ansible role installs Coder v2 on Ubuntu. It takes care of downloading the appropriate `.deb` package (either `amd64` or `arm64`), installing it, configuring the `coder.env` file, and enabling the service in `systemctl`.
 
+If the `coder_http_address` has a port < 1024, the role will also set `cap_net_bind_service=+ep` capability on the `coder` executable to make it run on the port without running as root.  ***The capability will be lost on upgrade, unless you upgrade using this same role***.
+
+You should make sure to upgrade `coder` with this role, or remember to run it after upgrading, else it will not be able to bind on a port < 1024 by default.
+
 Requirements
 ------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,3 +23,6 @@ galaxy_info:
     - ubuntu
 
 dependencies: []
+
+collections:
+  - community.general

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   register: coder_which_result
   changed_when: false
   ignore_errors: true
-  when: coder_http_port < 1024
+  when: coder_http_port | int < 1024
 
 - name: Resolve the full path of the 'coder' executable
   ansible.builtin.command: readlink -f "{{ coder_which_result.stdout }}"
@@ -51,16 +51,16 @@
   changed_when: false
   when:
     - coder_which_result.stdout != ""
-    - coder_http_port < 1024
+    - coder_http_port | int < 1024
   ignore_errors: true
 
 - name: Check current capabilities of 'coder' executable
-  ansible.builtin.stat:
-    path: "{{ coder_full_path_result.stdout }}"
-  register: coder_stat_result
+  ansible.builtin.command: getcap "{{ coder_full_path_result.stdout }}"
+  register: coder_capabilities_result
+  changed_when: false
   when:
     - coder_full_path_result.stdout != ""
-    - coder_http_port < 1024
+    - coder_http_port | int < 1024
 
 - name: Set 'cap_net_bind_service=+ep' capability on the 'coder' executable
   community.general.capabilities:
@@ -68,8 +68,8 @@
     capability: cap_net_bind_service=+ep
   when:
     - coder_full_path_result.stdout != ""
-    - "'cap_net_bind_service=+ep' not in coder_stat_result.stat.capabilities"
-    - coder_http_port < 1024
+    - "'cap_net_bind_service=+ep' not in coder_capabilities_result.stdout"
+    - coder_http_port | int < 1024
 
 - name: Create /etc/coder directory
   ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,7 +63,7 @@
     - coder_http_port < 1024
 
 - name: Set 'cap_net_bind_service=+ep' capability on the 'coder' executable
-  ansible.general.capabilities:
+  community.general.capabilities:
     path: "{{ coder_full_path_result.stdout }}"
     capability: cap_net_bind_service=+ep
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,6 +58,7 @@
   ansible.builtin.command: getcap "{{ coder_full_path_result.stdout }}"
   register: coder_capabilities_result
   changed_when: false
+  failed_when: coder_capabilities_result.rc not in [0, 1]
   when:
     - coder_full_path_result.stdout != ""
     - coder_http_port | int < 1024
@@ -68,7 +69,7 @@
     capability: cap_net_bind_service=+ep
   when:
     - coder_full_path_result.stdout != ""
-    - "'cap_net_bind_service=+ep' not in coder_capabilities_result.stdout"
+    - coder_capabilities_result.rc == 1
     - coder_http_port | int < 1024
 
 - name: Create /etc/coder directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,43 @@
     deb: "/tmp/coder.deb"
     state: present
 
+- name: Extract the port number from coder_http_address
+  ansible.builtin.set_fact:
+    coder_http_port: "{{ coder_http_address.split(':')[-1] | int }}"
+
+- name: Find the path of the 'coder' executable
+  ansible.builtin.command: which coder
+  register: coder_which_result
+  changed_when: false
+  ignore_errors: true
+  when: coder_http_port < 1024
+
+- name: Resolve the full path of the 'coder' executable
+  ansible.builtin.command: readlink -f "{{ coder_which_result.stdout }}"
+  register: coder_full_path_result
+  changed_when: false
+  when:
+    - coder_which_result.stdout != ""
+    - coder_http_port < 1024
+  ignore_errors: true
+
+- name: Check current capabilities of 'coder' executable
+  ansible.builtin.stat:
+    path: "{{ coder_full_path_result.stdout }}"
+  register: coder_stat_result
+  when:
+    - coder_full_path_result.stdout != ""
+    - coder_http_port < 1024
+
+- name: Set 'cap_net_bind_service=+ep' capability on the 'coder' executable
+  ansible.general.capabilities:
+    path: "{{ coder_full_path_result.stdout }}"
+    capability: cap_net_bind_service=+ep
+  when:
+    - coder_full_path_result.stdout != ""
+    - "'cap_net_bind_service=+ep' not in coder_stat_result.stat.capabilities"
+    - coder_http_port < 1024
+
 - name: Create /etc/coder directory
   ansible.builtin.file:
     path: /etc/coder.d


### PR DESCRIPTION
This PR enables steps to run to make the executable able to run on ports lower than 1024.  Those steps will be run selectively if the port is low enough to warrant it.

Closes #7 