### PR TITLE
feat(role): support configuration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This Ansible role installs Coder v2 on Ubuntu. It takes care of downloading the 
 
 If the `coder_http_address` has a port < 1024, the role will also set `cap_net_bind_service=+ep` capability on the `coder` executable to make it run on the port without running as root.  ***The capability will be lost on upgrade, unless you upgrade using this same role***.
 
+Any configuration change can be done by adding the variables in your playbook and running it again.
+
 You should make sure to upgrade `coder` with this role, or remember to run it after upgrading, else it will not be able to bind on a port < 1024 by default.
 
 Requirements

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,6 +84,7 @@
     src: coder.env.j2
     dest: /etc/coder.d/coder.env
     mode: '0644'
+  notify: Restart Coder
 
 - name: Enable and start Coder v2 service
   ansible.builtin.systemd:


### PR DESCRIPTION
This PR supports making configuration changes to Coder (via `coder.env`) through the role.

Closes #15 